### PR TITLE
Update globalize.rb

### DIFF
--- a/lib/administrate/field/globalize.rb
+++ b/lib/administrate/field/globalize.rb
@@ -8,15 +8,6 @@ module Administrate
       class Engine < ::Rails::Engine
         initializer "administrate-field-globalize.patch", before: :load_config_initializers do |app|
           Administrate::Search.class_eval do
-            def run
-              if @term.blank?
-                @scoped_resource.all
-              else
-                @scoped_resource.joins(tables_to_join).
-                  where(query, *search_terms).distinct
-              end
-            end
-
             def tables_to_join
               attribute_types.keys.select do |attribute|
                 attribute_types[attribute].searchable? && association_search?(attribute)
@@ -37,7 +28,15 @@ module Administrate
                     "#{@scoped_resource.table_name.singularize}_translations",
                 )
               elsif association_search?(attr)
-                ActiveRecord::Base.connection.quote_table_name(attr.to_s.pluralize)
+                provided_class_name = attribute_types[attr].options[:class_name]
+                unquoted_table_name =
+                  if provided_class_name
+                    Administrate.warn_of_deprecated_option(:class_name)
+                    provided_class_name.constantize.table_name
+                  else
+                    @scoped_resource.reflect_on_association(attr).klass.table_name
+                  end
+                ActiveRecord::Base.connection.quote_table_name(unquoted_table_name)
               else
                 ActiveRecord::Base.connection.
                   quote_table_name(@scoped_resource.table_name)


### PR DESCRIPTION
the `run` function breaks search in new administrate builds, also updated `query_table_name` to accommodate changes from the dashboard